### PR TITLE
use non-semantic version in POM if we have it.

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * language governing permissions and limitations under the License.
  */
 savantVersion = "2.0.0"
-project(group: "org.savantbuild.plugin", name: "pom", version: "2.0.0", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild.plugin", name: "pom", version: "2.0.1", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()
@@ -48,11 +48,11 @@ project(group: "org.savantbuild.plugin", name: "pom", version: "2.0.0", licenses
 }
 
 // Plugins
-dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0-RC.7")
-groovy = loadPlugin(id: "org.savantbuild.plugin:groovy:2.0.0-RC.6")
-groovyTestNG = loadPlugin(id: "org.savantbuild.plugin:groovy-testng:2.0.0-RC.6")
-idea = loadPlugin(id: "org.savantbuild.plugin:idea:2.0.0-RC.7")
-release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0-RC.6")
+dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.1")
+groovy = loadPlugin(id: "org.savantbuild.plugin:groovy:2.0.0")
+groovyTestNG = loadPlugin(id: "org.savantbuild.plugin:groovy-testng:2.0.0")
+idea = loadPlugin(id: "org.savantbuild.plugin:idea:2.0.0")
+release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0")
 
 // Plugin settings
 groovy.settings.groovyVersion = "4.0"

--- a/src/main/groovy/org/savantbuild/plugin/dep/maven/POMPlugin.groovy
+++ b/src/main/groovy/org/savantbuild/plugin/dep/maven/POMPlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2022-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,7 +126,11 @@ class POMPlugin extends BaseGroovyPlugin {
         Element dependency = appendNode(dependencies, "dependency", 4)
         setElement(dependency, "groupId", dep.id.group, 6)
         setElement(dependency, "artifactId", dep.id.name, 6)
-        setElement(dependency, "version", dep.version.toString(), 6)
+        // When we write out the pom.xml, we want to use the maven version if it is different
+        String version = dep.nonSemanticVersion != null
+            ? dep.nonSemanticVersion
+            : dep.version.toString();
+        setElement(dependency, "version", version, 6)
         setElement(dependency, "type", dep.id.type, 6)
         setElement(dependency, "scope", (String) options.scope, 6)
         setElement(dependency, "optional", (String) options.optional, 6)

--- a/src/test/groovy/org/savantbuild/plugin/dep/maven/POMPluginTest.groovy
+++ b/src/test/groovy/org/savantbuild/plugin/dep/maven/POMPluginTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2022-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,6 +80,7 @@ class POMPluginTest {
 
     project.dependencies = new Dependencies(
         new DependencyGroup("compile", true,
+            new Artifact(new ArtifactID("org.apache.commons", "org.apache.commons", "notSemver", "jar"), new Version("1.0.0"), "1.0.Final", false, null),
             new Artifact("org.savantbuild.test:multiple-versions:1.0.0"),
             new Artifact("org.savantbuild.test:multiple-versions-different-dependencies:2.0.0"),
             new Artifact("org.savantbuild.test:exclusions:2.0.0", null, false, [
@@ -127,8 +128,8 @@ class POMPluginTest {
 
     plugin.update()
 
-    String actual = new String(Files.readAllBytes(pomFile))
-    String expected = new String(Files.readAllBytes(projectDir.resolve("src/test/resources/pom-expected.xml")))
+    String actual = new String(Files.readAllBytes(pomFile)).trim();
+    String expected = new String(Files.readAllBytes(projectDir.resolve("src/test/resources/pom-expected.xml"))).trim();
     assertEquals(actual, expected)
   }
 }

--- a/src/test/resources/pom-expected.xml
+++ b/src/test/resources/pom-expected.xml
@@ -67,6 +67,14 @@
   <!-- Tight comment -->
   <dependencies>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>notSemver</artifactId>
+      <version>1.0.Final</version>
+      <type>jar</type>
+      <scope>compile</scope>
+      <optional>false</optional>
+    </dependency>
+    <dependency>
       <groupId>org.savantbuild.test</groupId>
       <artifactId>multiple-versions</artifactId>
       <version>1.0.0</version>


### PR DESCRIPTION
If the artifact has a non-semantic version, we should use that instead when building the `pom.xml`. 
This fixes the pom generation assuming the artifact was fetched from Maven to begin with. 